### PR TITLE
Delete Frame attribute

### DIFF
--- a/src/compas_masonry/elements/block.py
+++ b/src/compas_masonry/elements/block.py
@@ -2,7 +2,6 @@ from typing import Optional
 
 from compas.datastructures import Mesh
 from compas.geometry import Box
-from compas.geometry import Frame
 from compas.geometry import Plane
 from compas.geometry import Point
 from compas.geometry import Polyhedron
@@ -164,11 +163,10 @@ class BlockElement(Element):
         shape: BlockMesh,
         features: Optional[list[BlockFeature]] = None,
         is_support: bool = False,
-        frame: Optional[Frame] = None,
         transformation: Optional[Transformation] = None,
         name: Optional[str] = None,
     ) -> None:
-        super().__init__(frame=frame, transformation=transformation, features=features, name=name)
+        super().__init__(transformation=transformation, features=features, name=name)
 
         self.shape = shape
         self.is_support = is_support


### PR DESCRIPTION

I deleted the Frame attribute from the BlockElement class, as already done in compas_model and compas_dem.


### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [x] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
