### PR TITLE
Added fill and Masonry rho

### DIFF
--- a/commands/TNA_envelope.py
+++ b/commands/TNA_envelope.py
@@ -11,9 +11,8 @@ import compas_rhino.conversions
 import compas_rhino.objects
 from compas.datastructures import Mesh
 from compas_masonry.session import MasonrySession as Session
-from compas_tna.diagrams import FormDiagram
-
 from compas_rui import feedback
+from compas_tna.diagrams import FormDiagram
 from compas_tna.envelope import CrossVaultEnvelope
 from compas_tna.envelope import DomeEnvelope
 from compas_tna.envelope import Envelope
@@ -314,7 +313,7 @@ def RunCommand():
 
         if mesh_fill:
             envelope.fill = mesh_fill
-    
+
     # =============================================================================
     # Not supported
     # =============================================================================

--- a/commands/TNA_envelope.py
+++ b/commands/TNA_envelope.py
@@ -13,7 +13,7 @@ from compas.datastructures import Mesh
 from compas_masonry.session import MasonrySession as Session
 from compas_tna.diagrams import FormDiagram
 
-# from compas_rui import feedback
+from compas_rui import feedback
 from compas_tna.envelope import CrossVaultEnvelope
 from compas_tna.envelope import DomeEnvelope
 from compas_tna.envelope import Envelope
@@ -299,16 +299,47 @@ def RunCommand():
             obj = compas_rhino.objects.find_object(guid)
             mesh_middle = compas_rhino.conversions.mesh_to_compas(obj.Geometry, cls=Mesh)
 
+        guid = compas_rhino.objects.select_mesh("Select fill mesh (Optional)")
+        rs.UnselectAllObjects()
+        if not guid:
+            mesh_fill = None
+        else:
+            guids_bounds.append(guid)
+            obj = compas_rhino.objects.find_object(guid)
+            mesh_fill = compas_rhino.conversions.mesh_to_compas(obj.Geometry, cls=Mesh)
+
         rs.HideObjects(guids_bounds)
 
         envelope = MeshEnvelope.from_meshes(mesh_intrados, mesh_extrados, mesh_middle)
 
+        if mesh_fill:
+            envelope.fill = mesh_fill
+    
     # =============================================================================
     # Not supported
     # =============================================================================
 
     else:
         raise NotImplementedError
+
+    # =============================================================================
+    # Commom parameters
+    # =============================================================================
+
+    if not envelope:
+        feedback.warn("Error creating Envelope. Try again.")
+        return
+
+    rho = rs.GetInteger("Density masonry (rho)", envelope.rho, 0, 200)
+    if not rho:
+        return
+    envelope.rho = rho
+
+    if envelope.fill:
+        rho_fill = rs.GetInteger("Density masonry fill (rho_fill)", envelope.rho_fill, 0, 200)
+        if not rho_fill:
+            return
+        envelope.rho_fill = rho_fill
 
     # =============================================================================
     # Update scene
@@ -324,10 +355,13 @@ def RunCommand():
     show_intrados = session.settings.envelope.show_intrados
     show_middle = session.settings.envelope.show_middle
     show_extrados = session.settings.envelope.show_extrados
+    show_fill = session.settings.envelope.show_extrados
 
     session.scene.add(envelope.intrados, disjoint=True, show=show_intrados, name="Intrados", layer="Masonry::TNA::Envelope")  # type: ignore
     session.scene.add(envelope.middle, disjoint=True, show=show_middle, name="Middle", layer="Masonry::TNA::Envelope")  # type: ignore
     session.scene.add(envelope.extrados, disjoint=True, show=show_extrados, name="Extrados", layer="Masonry::TNA::Envelope")  # type: ignore
+    if envelope.fill:
+        session.scene.add(envelope.fill, disjoint=True, show=show_fill, name="Fill", layer="Masonry::TNA::Envelope")  # type: ignore
 
     session.scene.redraw()
     rs.Redraw()

--- a/commands/TNA_loads.py
+++ b/commands/TNA_loads.py
@@ -43,7 +43,7 @@ def RunCommand():
         return
 
     if option == "Add":
-        option = rs.GetString("Type of load", strings=["Selfweight", "External"])
+        option = rs.GetString("Type of load", strings=["Selfweight", "External", "FillLoads"])
         if not option:
             return
 
@@ -72,6 +72,12 @@ def RunCommand():
                     pz = formdiagram.vertex_attribute(key, "pz") or 0
                     print("Load at vertex {0} updated from {1:.2f} to {2:.2f}".format(key, pz, pz + load))
                     formdiagram.vertex_attribute(key, "pz", pz + load)
+
+        elif option == "FillLoads":
+            if not envelope.fill:
+                feedback.warn("There is no Fill Mesh. Please re-create envelope with a fill")
+                return
+            envelope.apply_fill_weight_to_formdiagram(formdiagram)
 
     elif option == "ClearAll":
         print("Cleared Loads in the Model.")

--- a/src/compas_masonry/scene/envelopeobject.py
+++ b/src/compas_masonry/scene/envelopeobject.py
@@ -23,6 +23,7 @@ class RhinoEnvelopeObject(RhinoSceneObject):
         show_intrados=True,
         show_middle=False,
         show_extrados=True,
+        show_fill=True,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -30,6 +31,7 @@ class RhinoEnvelopeObject(RhinoSceneObject):
         self.show_intrados = show_intrados
         self.show_middle = show_middle
         self.show_extrados = show_extrados
+        self.show_fill = show_fill
 
     @property
     def settings(self) -> dict:
@@ -38,6 +40,7 @@ class RhinoEnvelopeObject(RhinoSceneObject):
         settings["show_intrados"] = self.show_intrados
         settings["show_middle"] = self.show_middle
         settings["show_extrados"] = self.show_extrados
+        settings["show_fill"] = self.show_fill
         return settings
 
     @property
@@ -60,6 +63,9 @@ class RhinoEnvelopeObject(RhinoSceneObject):
 
         if self.show_extrados:
             self.draw_extrados()
+
+        if self.show_fill:
+            self.draw_fill()
 
         return self._guids
 
@@ -91,4 +97,10 @@ class RhinoEnvelopeObject(RhinoSceneObject):
         if not self.envelope.extrados:  # type: ignore
             return
         guid = self._draw_mesh(self.envelope.extrados, name="Extrados")  # type: ignore
+        self._guids.append(guid)
+
+    def draw_fill(self):
+        if not self.envelope.fill:
+            return
+        guid = self._draw_mesh(self.envelope.fill, name="Fill")  # type: ignore
         self._guids.append(guid)

--- a/src/compas_masonry/settings.py
+++ b/src/compas_masonry/settings.py
@@ -25,6 +25,7 @@ class EnvelopeSettings(BaseModel):
     show_intrados: bool = Field(default=True, title="Show Intrados")
     show_middle: bool = Field(default=False, title="Show Middle")
     show_extrados: bool = Field(default=True, title="Show Extrados")
+    show_fill: bool = Field(default=True, title="Show Fill")
 
 
 class BlockModelSettings(BaseModel):


### PR DESCRIPTION
This PR adds the option to add a fill mesh to the MeshEnvelope as an optional choice.

If a fill mesh is available FillLoads can be applied at TNA_Loads

I updated the settings to include a show_fill parameter.

@tomvanmele please can you check if the "Show Fill" option appears on your TNA_settings? 